### PR TITLE
Updated GH action cache version

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Adafruit Library Cache
         id: cache-mpy
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.adafruit-circuitpython-bundle
           key: ${{ runner.os }}-adafruit-mpy-${{ env.adafruit-bundle }}


### PR DESCRIPTION
Using old version of `actions/cache`:
```
Error: This request has been automatically failed because it uses a deprecated version of `actions/cache: v1`. 
Please update your workflow to use v3/v4 of actions/cache to avoid interruptions. 
Learn more: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down
```